### PR TITLE
Reduced state size being transferred to agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,7 @@ It is very easy to create your own agent by means of the API provided. Just inhe
 The game information received in those two methods is called quartoGameState. This is the structure of that data:
 ```
 [
-    current quarto board (4x4 numpy array),
-    current piece (integer),
+    game state encoding (string),
     available pieces (set of integers),
     available positions (set of integers)
 ]

--- a/experiments.py
+++ b/experiments.py
@@ -182,10 +182,11 @@ def create_table(path_to_dir: str):
 
 def main():
     #RUN YOUR TESTS HERE
-    # geneticminmax = qagents.GeneticMinmaxAgentTest(searchDepth=3, maxGenerations=3, initialPopulationSize=20000, maxPopulationSize=30000)
+    geneticminmax = qagents.GeneticMinmaxAgent(searchDepth=3, maxGenerations=3, initialPopulationSize=10000, maxPopulationSize=12000)
     # negamax= qagents.NegamaxAgent(depth=3, searchWindow=32)
-    # game = QuartoGame(negamax, geneticminmax, gui_mode=True, bin_mode=False)
-    # game.playRandomFirst()
+    #game = QuartoGame(negamax, geneticminmax, gui_mode=True, bin_mode=False)
+    game = QuartoGame(qagents.NegamaxAgent(depth=3, searchWindow=32), geneticminmax, gui_mode=True, bin_mode=False)
+    game.playRandomFirst()
     
     #negamax_tests()
     #genetic_tests()

--- a/quarto.py
+++ b/quarto.py
@@ -5,7 +5,7 @@ from datetime import datetime
 import time
 
 class QuartoGame:
-    def __init__(self, agent1: qagents.GenericQuartoAgent, agent2: qagents.GenericQuartoAgent, player1Name=None, player2Name=None, gui_mode=True, bin_mode=False):
+    def __init__(self, agent1: qagents.GenericQuartoAgent, agent2: qagents.GenericQuartoAgent, player1Name=None, player2Name=None, gui_mode=False, bin_mode=False):
         '''
         agent1:
             Agent initialized for player 1. 
@@ -134,10 +134,9 @@ class QuartoGame:
         
     def getGameState(self):
         return (
-            self.board,
-            self.currentPiece,
-            self.availablePieces,
-            self.availablePositions
+            self.encodeBoard(),
+            self.availablePieces.copy(),
+            self.availablePositions.copy()
             )
     
     # This method is ONLY for the first move of the game (the first player's first move)

--- a/quarto_agents/genetic_agent.py
+++ b/quarto_agents/genetic_agent.py
@@ -106,7 +106,7 @@ class GeneticMinmaxAgent(GenericQuartoAgent):
         return movePath
     
     def createChromosome(self, quartoGameState):
-        _, _, availableNextPieces, availablePositions = quartoGameState
+        _, availableNextPieces, availablePositions = quartoGameState
         tempNextPieces = availableNextPieces.copy()
         tempPositions = availablePositions.copy()
         chromosomeLength = self.searchDepth
@@ -161,9 +161,9 @@ class GeneticMinmaxAgent(GenericQuartoAgent):
             mutationPoint = np.random.choice(pieces)
 
         if mutationPoint % 2 == 0: #move position
-            mutation = sample(quartoGameState[3], 1)[0] 
+            mutation = sample(quartoGameState[2], 1)[0] 
         else: #move nextPiece
-            mutation = sample(quartoGameState[2], 1)[0]
+            mutation = sample(quartoGameState[1], 1)[0]
 
         move = ""
         if mutation <= 9:
@@ -177,8 +177,8 @@ class GeneticMinmaxAgent(GenericQuartoAgent):
     
     def isValidChromosome(self, chromosome, quartoGameState):
         #check if chromosome is valid
-        positions = [int(chromosome[i:i+2]) for i in range(0,len(chromosome),4)] + list(set(range(16)) - quartoGameState[3])
-        nextPieces = [int(chromosome[i:i+2]) for i in range(2,len(chromosome),4)] + list(set(range(16)) - quartoGameState[2])
+        positions = [int(chromosome[i:i+2]) for i in range(0,len(chromosome),4)] + list(set(range(16)) - quartoGameState[2])
+        nextPieces = [int(chromosome[i:i+2]) for i in range(2,len(chromosome),4)] + list(set(range(16)) - quartoGameState[1])
         if len(set(positions)) < len(positions):
             return False
         if len(set(nextPieces)) < len(nextPieces):
@@ -190,8 +190,8 @@ class GeneticMinmaxAgent(GenericQuartoAgent):
     def evaluate(self, chromosome, quartoGameState):
         movePath = [(int(chromosome[i]+chromosome[i+1]),int(chromosome[i+2]+chromosome[i+3])) for i in range(0,len(chromosome)-3,4)]
 
-        boardEncoding = qutil.encodeBoard(quartoGameState[0], quartoGameState[1])
-        tempCurrentPiece = quartoGameState[1]
+        boardEncoding = quartoGameState[0]
+        tempCurrentPiece = int(boardEncoding[-2:])
         evaluation = 0
         myTurn = True
         isGameOver = False
@@ -241,7 +241,7 @@ class GeneticMinmaxAgent(GenericQuartoAgent):
         maxPopulationSize = self.maxPopulationSize
         self.fitnessCountLimit = self.maxPopulationSize
 
-        numPossibleMoves = len(quartoGameState[3])
+        numPossibleMoves = len(quartoGameState[2])
         if numPossibleMoves >  self.searchDepth:
             maxPossibleStates = self.getNumStates(numPossibleMoves)
             if maxPossibleStates < initialPopulationSize:

--- a/quarto_agents/random_agent.py
+++ b/quarto_agents/random_agent.py
@@ -8,11 +8,11 @@ class RandomAgent(GenericQuartoAgent):
         super().setName("Random Agent")
 
     def makeFirstMove(self, quartoGameState, gui_mode=False):
-        nextPiece = random.choice(list(quartoGameState[2]))
+        nextPiece = random.choice(list(quartoGameState[1]))
         return nextPiece
     
     def makeMove(self, quartoGameState, gui_mode=False):
-        position = random.choice(list(quartoGameState[3]))
-        nextPiece = random.choice(list(quartoGameState[2]))
+        position = random.choice(list(quartoGameState[2]))
+        nextPiece = random.choice(list(quartoGameState[1]))
         if gui_mode: print(f"Random agent placed piece at cell {position} and nextPiece is {nextPiece}")
         return position, nextPiece


### PR DESCRIPTION
Quarto simulator will return the board encoding and shallow copies of the two sets when sending the game state to the agents for safety and data efficiency. This means the agent cannot alter the actual game state like before and the state being sent is a smaller size than sending an 2d array for the board